### PR TITLE
Add project areas and blocked tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -355,7 +355,7 @@ Areas are **per-project** (`ProjectArea`, unique on `[projectId, name]`) — the
 - `isLead` on `ProjectAreaMember` is the **"Area PM"** label. It grants **no** permissions and is checked nowhere on the server — any project member can still edit any task and set assignees. Do not add enforcement without asking.
 - Area colors come from the static map in `_components/areaColors.ts`. Tailwind v4 only emits classes it sees literally, so never build those class names by interpolation.
 - `BLOCKED` sits between `IN_PROGRESS` and `IN_REVIEW` and models cross-area dependencies. `blockedReason` / `blockedByAreaId` are **nulled out** by `createTask`/`updateTask` whenever status becomes anything else.
-- Board filters (area multi-select + person) fold into `tasksByStatus` in `BoardTab.tsx` — the single hook point feeding all five columns. Filtering by area X matches tasks **tagged** X *or* `blockedByAreaId === X`, so a Vision lead also sees the work stalled on them (marked `⛔ blocking you`).
+- Board filters (area multi-select + person) fold into `tasksByStatus` in `BoardTab.tsx` — the single hook point feeding all five columns. Filtering by area X matches tasks **tagged** X *or* `blockedByAreaId === X`, so a lead also sees the work stalled on them (marked `⛔ blocking you`).
 
 ### Work plan reviewer flow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,9 @@ Key models and their purpose:
 | `Project` | Team project (can be private); has `miroBoard` embed URL |
 | `ProjectLink` | Named URL links attached to a project (visible in Overview tab) |
 | `ProjectMember` | Member ↔ project role (PROJECT_MEMBER / PROJECT_MANAGER) |
+| `ProjectArea` | Technical area within a project — per-project, no global catalog |
+| `ProjectAreaMember` | Member ↔ area, with `isLead` ("Area PM") — **display only, not enforced** |
+| `TaskArea` | Task ↔ area tag (a task may carry several areas) |
 | `Task` | Task within a project (Kanban board) |
 | `TaskAssignee` | Member ↔ task assignment |
 | `TaskComment` | Comment on a task |
@@ -330,7 +333,7 @@ enum CompletionStatus  { PENDING  APPROVED  REJECTED }
 enum ProfileEditStatus { PENDING  APPROVED  REJECTED }
 enum ProjectStatus     { ACTIVE  COMPLETED  ARCHIVED }
 enum ProjectRole       { PROJECT_MEMBER  PROJECT_MANAGER }
-enum TaskStatus        { TODO  IN_PROGRESS  IN_REVIEW  DONE }
+enum TaskStatus        { TODO  IN_PROGRESS  BLOCKED  IN_REVIEW  DONE }
 enum TaskPriority      { LOW  MEDIUM  HIGH  URGENT }
 enum AttendanceMethod  { QR_CODE  MANUAL  SELF }
 ```
@@ -344,6 +347,15 @@ enum AttendanceMethod  { QR_CODE  MANUAL  SELF }
 ### Admin-only project roles
 
 ADMIN users always hold `PROJECT_MANAGER` role on any project they join — enforced in `addMember` and blocked in `updateMemberRole`. Users cannot change their own project role.
+
+### Project areas & blocked tasks
+
+Areas are **per-project** (`ProjectArea`, unique on `[projectId, name]`) — there is no team-wide catalog. A task can carry several areas; a member can belong to several.
+
+- `isLead` on `ProjectAreaMember` is the **"Area PM"** label. It grants **no** permissions and is checked nowhere on the server — any project member can still edit any task and set assignees. Do not add enforcement without asking.
+- Area colors come from the static map in `_components/areaColors.ts`. Tailwind v4 only emits classes it sees literally, so never build those class names by interpolation.
+- `BLOCKED` sits between `IN_PROGRESS` and `IN_REVIEW` and models cross-area dependencies. `blockedReason` / `blockedByAreaId` are **nulled out** by `createTask`/`updateTask` whenever status becomes anything else.
+- Board filters (area multi-select + person) fold into `tasksByStatus` in `BoardTab.tsx` — the single hook point feeding all five columns. Filtering by area X matches tasks **tagged** X *or* `blockedByAreaId === X`, so a Vision lead also sees the work stalled on them (marked `⛔ blocking you`).
 
 ### Work plan reviewer flow
 
@@ -367,7 +379,7 @@ ADMIN users always hold `PROJECT_MANAGER` role on any project they join — enfo
 | Router | Key procedures |
 |---|---|
 | `member` | `getDirectory`, `getById`, `update`, `updateRole`, `updateStatus` |
-| `project` | `getAll`, `getById`, `create`, `update`, `updateLinks`, `addMember`, `removeMember`, `updateMemberRole` |
+| `project` | `getAll`, `getById`, `create`, `update`, `updateLinks`, `addMember`, `removeMember`, `updateMemberRole`, `getAreas`, `createArea`, `updateArea`, `deleteArea`, `setMemberAreas` |
 | `workPlan` | `getActivities`, `getLeaderboard`, `submitCompletion`, `getPendingCompletions`, `reviewCompletion`, `getActivityReviewers`, `addActivityReviewer`, `removeActivityReviewer` |
 | `attendance` | `getMeetings`, `createMeeting`, `checkIn`, `getAttendanceReport` |
 | `webProject` | `getAll`, `create`, `update`, `delete` |

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,7 @@ enum ProjectRole {
 enum TaskStatus {
     TODO
     IN_PROGRESS
+    BLOCKED
     IN_REVIEW
     DONE
 }
@@ -159,6 +160,7 @@ model User {
     // Project relations
     projectsCreated Project[]       @relation("ProjectCreator")
     projectMembers  ProjectMember[]
+    projectAreas    ProjectAreaMember[]
     tasksCreated     Task[]           @relation("TaskCreator")
     taskAssignments  TaskAssignee[]
     taskComments     TaskComment[]
@@ -408,8 +410,49 @@ model Project {
     tasks    Task[]
     meetings Meeting[]
     links    ProjectLink[]
+    areas    ProjectArea[]
 
     @@index([status])
+}
+
+/// A technical area within a project.
+model ProjectArea {
+    id        String   @id @default(cuid())
+    projectId String
+    name      String
+    color     String? // palette key — see areaColors.ts
+    order     Int      @default(0)
+
+    project      Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+    members      ProjectAreaMember[]
+    tasks        TaskArea[]
+    blockedTasks Task[]              @relation("TaskBlockedByArea")
+
+    @@unique([projectId, name])
+    @@index([projectId])
+}
+
+model ProjectAreaMember {
+    areaId String
+    userId String
+    isLead Boolean @default(false) // "Area PM"
+
+    area ProjectArea @relation(fields: [areaId], references: [id], onDelete: Cascade)
+    user User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+    @@id([areaId, userId])
+    @@index([userId])
+}
+
+model TaskArea {
+    taskId String
+    areaId String
+
+    task Task        @relation(fields: [taskId], references: [id], onDelete: Cascade)
+    area ProjectArea @relation(fields: [areaId], references: [id], onDelete: Cascade)
+
+    @@id([taskId, areaId])
+    @@index([areaId])
 }
 
 model ProjectLink {
@@ -451,12 +494,17 @@ model Task {
     createdBy   String
     createdAt   DateTime     @default(now())
     updatedAt   DateTime     @updatedAt
+    // Only meaningful while status is BLOCKED.
+    blockedReason   String?
+    blockedByAreaId String?
 
     project   Project        @relation(fields: [projectId], references: [id], onDelete: Cascade)
     creator   User           @relation("TaskCreator", fields: [createdBy], references: [id])
     assignees    TaskAssignee[]
     comments     TaskComment[]
     attachments  TaskAttachment[]
+    areas         TaskArea[]
+    blockedByArea ProjectArea? @relation("TaskBlockedByArea", fields: [blockedByAreaId], references: [id], onDelete: SetNull)
 
     @@index([projectId])
     @@index([status])

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -160,7 +160,7 @@ const TOOLS = [
         priority: { type: "string", enum: ["LOW", "MEDIUM", "HIGH", "URGENT"] },
         status: {
           type: "string",
-          enum: ["TODO", "IN_PROGRESS", "IN_REVIEW", "DONE"],
+          enum: ["TODO", "IN_PROGRESS", "BLOCKED", "IN_REVIEW", "DONE"],
         },
       },
     },
@@ -647,7 +647,12 @@ async function callTool(
           priority:
             (args.priority as "LOW" | "MEDIUM" | "HIGH" | "URGENT") ?? "MEDIUM",
           status:
-            (args.status as "TODO" | "IN_PROGRESS" | "IN_REVIEW" | "DONE") ??
+            (args.status as
+              | "TODO"
+              | "IN_PROGRESS"
+              | "BLOCKED"
+              | "IN_REVIEW"
+              | "DONE") ??
             "TODO",
           createdBy: user.id,
         },

--- a/src/app/dashboard/projects/[id]/_components/BoardTab.tsx
+++ b/src/app/dashboard/projects/[id]/_components/BoardTab.tsx
@@ -96,8 +96,7 @@ export function BoardTab({
 
   const isFiltered = areaFilter.length > 0 || personFilter !== null;
 
-  // An area filter matches a task tagged with that area OR blocked waiting on
-  // it, so a Vision lead filtering to Vision also sees the work stalled on them.
+  // An area filter matches a task tagged with that area OR blocked waiting on it.
   const filtered = useMemo(() => {
     if (!tasks || !isFiltered) return tasks ?? [];
     return tasks.filter((t) => {

--- a/src/app/dashboard/projects/[id]/_components/BoardTab.tsx
+++ b/src/app/dashboard/projects/[id]/_components/BoardTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -13,13 +13,15 @@ import {
 import { useDroppable, useDraggable } from "@dnd-kit/core";
 
 import { api, type RouterOutputs } from "~/trpc/react";
+import { areaColor } from "./areaColors";
 
 type Task = RouterOutputs["project"]["getTasks"][0];
-type TaskStatus = "TODO" | "IN_PROGRESS" | "IN_REVIEW" | "DONE";
+type TaskStatus = "TODO" | "IN_PROGRESS" | "BLOCKED" | "IN_REVIEW" | "DONE";
 
 const COLUMNS: { id: TaskStatus; label: string; color: string }[] = [
   { id: "TODO", label: "To Do", color: "bg-gray-100" },
   { id: "IN_PROGRESS", label: "In Progress", color: "bg-blue-50" },
+  { id: "BLOCKED", label: "Blocked", color: "bg-red-50" },
   { id: "IN_REVIEW", label: "In Review", color: "bg-yellow-50" },
   { id: "DONE", label: "Done", color: "bg-green-50" },
 ];
@@ -46,8 +48,12 @@ export function BoardTab({
 }) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const [addingToColumn, setAddingToColumn] = useState<TaskStatus | null>(null);
+  const [areaFilter, setAreaFilter] = useState<string[]>([]);
+  const [personFilter, setPersonFilter] = useState<string | null>(null);
 
   const { data: tasks } = api.project.getTasks.useQuery({ projectId });
+  const { data: areas } = api.project.getAreas.useQuery({ projectId });
+  const { data: members } = api.project.getProjectMembers.useQuery({ projectId });
   const utils = api.useUtils();
 
   const updateTask = api.project.updateTask.useMutation({
@@ -83,11 +89,37 @@ export function BoardTab({
     const task = tasks?.find((t) => t.id === active.id);
     if (task && task.status !== newStatus) {
       updateTask.mutate({ id: task.id, status: newStatus });
+      // Blocking is only useful with a reason — open the panel on the empty field
+      if (newStatus === "BLOCKED") onSelectTask(task.id);
     }
   }
 
+  const isFiltered = areaFilter.length > 0 || personFilter !== null;
+
+  // An area filter matches a task tagged with that area OR blocked waiting on
+  // it, so a Vision lead filtering to Vision also sees the work stalled on them.
+  const filtered = useMemo(() => {
+    if (!tasks || !isFiltered) return tasks ?? [];
+    return tasks.filter((t) => {
+      if (personFilter && !t.assignees.some((a) => a.user.id === personFilter))
+        return false;
+      if (areaFilter.length === 0) return true;
+      return (
+        t.areas.some((a) => areaFilter.includes(a.areaId)) ||
+        (t.blockedByAreaId !== null && areaFilter.includes(t.blockedByAreaId))
+      );
+    });
+  }, [tasks, areaFilter, personFilter, isFiltered]);
+
+  /// True when a task surfaced only because it is blocking a filtered area.
+  const isBlockingYou = (task: Task) =>
+    areaFilter.length > 0 &&
+    task.blockedByAreaId !== null &&
+    areaFilter.includes(task.blockedByAreaId) &&
+    !task.areas.some((a) => areaFilter.includes(a.areaId));
+
   const tasksByStatus = (status: TaskStatus) =>
-    tasks?.filter((t) => t.status === status) ?? [];
+    filtered.filter((t) => t.status === status);
 
   return (
     <DndContext
@@ -95,6 +127,64 @@ export function BoardTab({
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 mb-3">
+        {(areas ?? []).map((area) => {
+          const active = areaFilter.includes(area.id);
+          return (
+            <button
+              key={area.id}
+              onClick={() =>
+                setAreaFilter((prev) =>
+                  prev.includes(area.id)
+                    ? prev.filter((a) => a !== area.id)
+                    : [...prev, area.id],
+                )
+              }
+              className={`px-2.5 py-1 text-xs rounded-lg border font-medium transition-colors ${
+                active
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "bg-white text-gray-600 border-gray-300 hover:bg-gray-50"
+              }`}
+            >
+              <span
+                className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle ${active ? "bg-white/80" : areaColor(area.color).dot}`}
+              />
+              {area.name}
+            </button>
+          );
+        })}
+
+        <select
+          value={personFilter ?? ""}
+          onChange={(e) => setPersonFilter(e.target.value || null)}
+          className="text-xs rounded-lg border border-gray-300 px-2 py-1 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400"
+        >
+          <option value="">Anyone</option>
+          {(members ?? []).map((m) => (
+            <option key={m.userId} value={m.userId}>
+              {m.user.name ?? m.user.email}
+            </option>
+          ))}
+        </select>
+
+        {isFiltered && (
+          <>
+            <span className="text-xs text-gray-500">
+              {filtered.length} of {tasks?.length ?? 0} tasks
+            </span>
+            <button
+              onClick={() => {
+                setAreaFilter([]);
+                setPersonFilter(null);
+              }}
+              className="text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 px-2 py-1 rounded transition-colors"
+            >
+              ✕ Clear
+            </button>
+          </>
+        )}
+      </div>
+
       <div className="flex gap-3 overflow-x-auto pb-4">
         {COLUMNS.map((col) => (
           <Column
@@ -108,6 +198,7 @@ export function BoardTab({
             onStartAdd={() => setAddingToColumn(col.id)}
             onDoneAdd={() => setAddingToColumn(null)}
             projectId={projectId}
+            isBlockingYou={isBlockingYou}
           />
         ))}
       </div>
@@ -128,6 +219,7 @@ function Column({
   onStartAdd,
   onDoneAdd,
   projectId,
+  isBlockingYou,
 }: {
   column: (typeof COLUMNS)[0];
   tasks: Task[];
@@ -138,6 +230,7 @@ function Column({
   onStartAdd: () => void;
   onDoneAdd: () => void;
   projectId: string;
+  isBlockingYou: (task: Task) => boolean;
 }) {
   const { setNodeRef, isOver } = useDroppable({ id: column.id });
 
@@ -161,6 +254,7 @@ function Column({
             key={task.id}
             task={task}
             isSelected={selectedTaskId === task.id}
+            isBlockingYou={isBlockingYou(task)}
             onClick={() =>
               onSelectTask(selectedTaskId === task.id ? null : task.id)
             }
@@ -189,10 +283,12 @@ function Column({
 function DraggableTaskCard({
   task,
   isSelected,
+  isBlockingYou,
   onClick,
 }: {
   task: Task;
   isSelected: boolean;
+  isBlockingYou: boolean;
   onClick: () => void;
 }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
@@ -206,7 +302,12 @@ function DraggableTaskCard({
       {...listeners}
       className={isDragging ? "opacity-40" : ""}
     >
-      <TaskCard task={task} isSelected={isSelected} onClick={onClick} />
+      <TaskCard
+        task={task}
+        isSelected={isSelected}
+        isBlockingYou={isBlockingYou}
+        onClick={onClick}
+      />
     </div>
   );
 }
@@ -215,17 +316,19 @@ function TaskCard({
   task,
   isSelected,
   isDragging,
+  isBlockingYou,
   onClick,
 }: {
   task: Task;
   isSelected?: boolean;
   isDragging?: boolean;
+  isBlockingYou?: boolean;
   onClick?: () => void;
 }) {
   return (
     <div
       onClick={onClick}
-      className={`bg-white rounded-lg border p-3 cursor-pointer select-none shadow-sm transition-all ${
+      className={`bg-white rounded-lg border p-3 cursor-pointer select-none shadow-sm transition-all ${isBlockingYou ? "border-l-4 border-l-red-500" : ""} ${
         isDragging
           ? "shadow-lg rotate-1 border-blue-200"
           : isSelected
@@ -233,9 +336,32 @@ function TaskCard({
             : "border-gray-200 hover:border-blue-200 hover:shadow-md"
       }`}
     >
+      {isBlockingYou && (
+        <p className="text-[10px] font-semibold text-red-600 mb-1">⛔ blocking you</p>
+      )}
+
       <p className="text-sm text-gray-900 font-medium leading-snug mb-2">
         {task.title}
       </p>
+
+      {task.status === "BLOCKED" && (
+        <p className="text-[10px] text-red-600 mb-2 truncate" title={task.blockedReason ?? undefined}>
+          ⛔ {task.blockedByArea ? `waiting on ${task.blockedByArea.name}` : "blocked"}
+        </p>
+      )}
+
+      {task.areas.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {task.areas.map(({ area }) => (
+            <span
+              key={area.id}
+              className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${areaColor(area.color).chip}`}
+            >
+              {area.name}
+            </span>
+          ))}
+        </div>
+      )}
 
       <div className="flex items-center justify-between gap-1">
         <span

--- a/src/app/dashboard/projects/[id]/_components/MembersTab.tsx
+++ b/src/app/dashboard/projects/[id]/_components/MembersTab.tsx
@@ -214,7 +214,7 @@ function AreasPanel({
         ))}
         {areas.length === 0 && (
           <p className="text-xs text-gray-400">
-            No areas yet — split the project into tracks like HRI or Vision.
+            No areas yet.
           </p>
         )}
       </div>

--- a/src/app/dashboard/projects/[id]/_components/MembersTab.tsx
+++ b/src/app/dashboard/projects/[id]/_components/MembersTab.tsx
@@ -2,9 +2,12 @@
 
 import { useRef, useState } from "react";
 import { api, type RouterOutputs } from "~/trpc/react";
+import { AREA_COLOR_KEYS, areaColor } from "./areaColors";
 
 type Project = RouterOutputs["project"]["getById"];
 type ProjectMember = Project["members"][0];
+type Area = RouterOutputs["project"]["getAreas"][0];
+type MemberArea = { area: Area; isLead: boolean };
 
 export function MembersTab({
   project,
@@ -16,20 +19,56 @@ export function MembersTab({
   currentUserId: string;
 }) {
   const [showAdd, setShowAdd] = useState(false);
+  const [areaFilter, setAreaFilter] = useState<string[]>([]);
   const utils = api.useUtils();
+
+  const { data: areas } = api.project.getAreas.useQuery({ projectId: project.id });
 
   function invalidate() {
     void utils.project.getById.invalidate({ id: project.id });
   }
 
+  function invalidateAreas() {
+    void utils.project.getAreas.invalidate({ projectId: project.id });
+    void utils.project.getTasks.invalidate({ projectId: project.id });
+  }
+
   const removeMember = api.project.removeMember.useMutation({ onSuccess: invalidate });
   const updateRole = api.project.updateMemberRole.useMutation({ onSuccess: invalidate });
+  const setMemberAreas = api.project.setMemberAreas.useMutation({ onSuccess: invalidateAreas });
+
+  // getAreas already carries each area's membership.
+  const areasByUser = new Map<string, MemberArea[]>();
+  for (const area of areas ?? []) {
+    for (const m of area.members) {
+      const list = areasByUser.get(m.userId) ?? [];
+      list.push({ area, isLead: m.isLead });
+      areasByUser.set(m.userId, list);
+    }
+  }
+
+  // Members matching any selected area
+  const shownMembers =
+    areaFilter.length === 0
+      ? project.members
+      : project.members.filter((m) =>
+          (areasByUser.get(m.userId) ?? []).some((a) => areaFilter.includes(a.area.id)),
+        );
 
   return (
     <div className="max-w-2xl space-y-4">
+      <AreasPanel
+        projectId={project.id}
+        areas={areas ?? []}
+        isManager={isManager}
+        onChanged={invalidateAreas}
+      />
+
       <div className="flex items-center justify-between">
         <h2 className="font-semibold text-gray-900">
-          {project.members.length} Member{project.members.length !== 1 ? "s" : ""}
+          {areaFilter.length > 0
+            ? `${shownMembers.length} of ${project.members.length} Members`
+            : `${project.members.length} Member${project.members.length !== 1 ? "s" : ""}`}
         </h2>
         {isManager && (
           <button
@@ -41,6 +80,44 @@ export function MembersTab({
         )}
       </div>
 
+      {(areas ?? []).length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {(areas ?? []).map((area) => {
+            const active = areaFilter.includes(area.id);
+            return (
+              <button
+                key={area.id}
+                onClick={() =>
+                  setAreaFilter((prev) =>
+                    prev.includes(area.id)
+                      ? prev.filter((a) => a !== area.id)
+                      : [...prev, area.id],
+                  )
+                }
+                className={`px-2.5 py-1 text-xs rounded-lg border font-medium transition-colors ${
+                  active
+                    ? "bg-blue-600 text-white border-blue-600"
+                    : "bg-white text-gray-600 border-gray-300 hover:bg-gray-50"
+                }`}
+              >
+                <span
+                  className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle ${active ? "bg-white/80" : areaColor(area.color).dot}`}
+                />
+                {area.name}
+              </button>
+            );
+          })}
+          {areaFilter.length > 0 && (
+            <button
+              onClick={() => setAreaFilter([])}
+              className="text-xs text-gray-500 hover:text-gray-700 hover:bg-gray-100 px-2 py-1 rounded transition-colors"
+            >
+              ✕ Clear
+            </button>
+          )}
+        </div>
+      )}
+
       {showAdd && (
         <AddMemberPanel
           projectId={project.id}
@@ -50,12 +127,22 @@ export function MembersTab({
       )}
 
       <div className="bg-white rounded-xl border border-gray-200 shadow-sm divide-y divide-gray-100">
-        {project.members.map((m) => (
+        {shownMembers.length === 0 && (
+          <p className="px-4 py-6 text-sm text-gray-400 text-center">
+            No members in the selected area{areaFilter.length !== 1 ? "s" : ""}.
+          </p>
+        )}
+        {shownMembers.map((m) => (
           <MemberRow
             key={m.id}
             member={m}
             isManager={isManager}
             isCurrentUser={m.userId === currentUserId}
+            allAreas={areas ?? []}
+            memberAreas={areasByUser.get(m.userId) ?? []}
+            onSetAreas={(next) =>
+              setMemberAreas.mutate({ projectId: project.id, userId: m.userId, areas: next })
+            }
             onRoleChange={(role) =>
               updateRole.mutate({ projectId: project.id, userId: m.userId, role })
             }
@@ -70,10 +157,110 @@ export function MembersTab({
   );
 }
 
+/// Manager-only CRUD over the project's areas.
+function AreasPanel({
+  projectId,
+  areas,
+  isManager,
+  onChanged,
+}: {
+  projectId: string;
+  areas: Area[];
+  isManager: boolean;
+  onChanged: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string>(AREA_COLOR_KEYS[0]!);
+
+  const createArea = api.project.createArea.useMutation({
+    onSuccess: () => { onChanged(); setName(""); },
+  });
+  const deleteArea = api.project.deleteArea.useMutation({ onSuccess: onChanged });
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-gray-900 text-sm">
+          Areas <span className="font-normal text-gray-400">({areas.length})</span>
+        </h2>
+        {isManager && (
+          <button onClick={() => setOpen(!open)} className="text-xs text-gray-500 hover:text-gray-700">
+            {open ? "Done" : "Manage"}
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-1.5 mt-2">
+        {areas.map((a) => (
+          <span
+            key={a.id}
+            className={`text-xs font-medium px-2 py-0.5 rounded ${areaColor(a.color).chip}`}
+          >
+            {a.name} <span className="opacity-60">{a._count.tasks}</span>
+            {open && (
+              <button
+                onClick={() => {
+                  if (confirm(`Delete area "${a.name}"? Tasks keep existing, untagged.`))
+                    deleteArea.mutate({ id: a.id });
+                }}
+                className="ml-1 opacity-60 hover:opacity-100"
+                aria-label="Delete area"
+              >
+                ×
+              </button>
+            )}
+          </span>
+        ))}
+        {areas.length === 0 && (
+          <p className="text-xs text-gray-400">
+            No areas yet — split the project into tracks like HRI or Vision.
+          </p>
+        )}
+      </div>
+
+      {open && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (name.trim()) createArea.mutate({ projectId, name: name.trim(), color });
+          }}
+          className="flex items-center gap-2 mt-3"
+        >
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="New area name…"
+            className="flex-1 min-w-0 text-sm rounded border border-gray-300 px-2 py-1 focus:outline-none focus:ring-1 focus:ring-blue-400"
+          />
+          <select
+            value={color}
+            onChange={(e) => setColor(e.target.value)}
+            className="text-xs rounded border border-gray-300 px-2 py-1 bg-white focus:outline-none focus:ring-1 focus:ring-blue-400"
+          >
+            {AREA_COLOR_KEYS.map((c) => <option key={c} value={c}>{c}</option>)}
+          </select>
+          <button
+            type="submit"
+            disabled={!name.trim() || createArea.isPending}
+            className="text-xs px-2.5 py-1.5 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            Add
+          </button>
+        </form>
+      )}
+      {createArea.error && <p className="text-xs text-red-600 mt-2">{createArea.error.message}</p>}
+    </div>
+  );
+}
+
 function MemberRow({
   member,
   isManager,
   isCurrentUser,
+  allAreas,
+  memberAreas,
+  onSetAreas,
   onRoleChange,
   onRemove,
   isSaving,
@@ -81,11 +268,22 @@ function MemberRow({
   member: ProjectMember;
   isManager: boolean;
   isCurrentUser: boolean;
+  allAreas: Area[];
+  memberAreas: MemberArea[];
+  onSetAreas: (areas: { areaId: string; isLead: boolean }[]) => void;
   onRoleChange: (role: "PROJECT_MEMBER" | "PROJECT_MANAGER") => void;
   onRemove: () => void;
   isSaving: boolean;
 }) {
+  const [editingAreas, setEditingAreas] = useState(false);
+  const current = new Map(memberAreas.map((m) => [m.area.id, m.isLead]));
+
+  function commit(next: Map<string, boolean>) {
+    onSetAreas([...next].map(([areaId, isLead]) => ({ areaId, isLead })));
+  }
+
   return (
+    <div>
     <div className="flex items-center gap-3 px-4 py-3">
       {member.user.image ? (
         // eslint-disable-next-line @next/next/no-img-element
@@ -114,6 +312,27 @@ function MemberRow({
         </span>
       )}
 
+      <div className="flex flex-wrap gap-1 justify-end shrink-0 max-w-56">
+        {memberAreas.map(({ area, isLead }) => (
+          <span
+            key={area.id}
+            className={`text-xs font-medium px-2 py-0.5 rounded ${areaColor(area.color).chip}`}
+            title={isLead ? `Area PM of ${area.name} — label only, grants no permissions` : area.name}
+          >
+            {isLead && "★ "}{area.name}
+          </span>
+        ))}
+        {isManager && allAreas.length > 0 && (
+          <button
+            onClick={() => setEditingAreas(!editingAreas)}
+            className="text-xs text-gray-400 hover:text-gray-600 px-1 transition-colors"
+            title="Edit areas"
+          >
+            {editingAreas ? "✕" : "＋"}
+          </button>
+        )}
+      </div>
+
       {isManager && !isCurrentUser && member.user.role !== "ADMIN" ? (
         <select
           value={member.role}
@@ -141,6 +360,59 @@ function MemberRow({
         >
           Remove
         </button>
+      )}
+    </div>
+
+      {editingAreas && (
+        <div className="px-4 pb-3">
+          <p className="text-xs text-gray-400 mb-1.5">
+            Click an area to join or leave it. Click the ★ to make this member the
+            area&apos;s PM.
+          </p>
+          <div className="flex flex-wrap gap-1.5 items-center">
+            {allAreas.map((a) => {
+              const joined = current.has(a.id);
+              const isLead = current.get(a.id) ?? false;
+              // Whoever currently holds this area's PM, if not this member
+              const otherLead = a.members.find((m) => m.isLead && m.userId !== member.userId);
+              return (
+                <span
+                  key={a.id}
+                  className={`text-xs font-medium px-2 py-0.5 rounded ${
+                    joined ? areaColor(a.color).chip : "bg-white text-gray-400 border border-gray-200"
+                  }`}
+                >
+                  <button
+                    onClick={() => {
+                      const next = new Map(current);
+                      if (joined) next.delete(a.id);
+                      else next.set(a.id, false);
+                      commit(next);
+                    }}
+                    title={joined ? `Leave ${a.name}` : `Join ${a.name}`}
+                  >
+                    {a.name}
+                  </button>
+                  {joined && (
+                    <button
+                      onClick={() => commit(new Map(current).set(a.id, !isLead))}
+                      className={`ml-1 ${isLead ? "" : "opacity-30"}`}
+                      title={
+                        isLead
+                          ? `Remove as PM of ${a.name}`
+                          : otherLead
+                            ? `Make PM of ${a.name} — replaces ${otherLead.user.name ?? "the current PM"}`
+                            : `Make PM of ${a.name}`
+                      }
+                    >
+                      ★
+                    </button>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        </div>
       )}
     </div>
   );
@@ -174,8 +446,8 @@ function AddMemberPanel({
   const filtered = (available ?? []).filter((u) => {
     const q = search.toLowerCase();
     return (
-      u.name?.toLowerCase().includes(q) ??
-      u.email?.toLowerCase().includes(q)
+      (u.name?.toLowerCase().includes(q) ?? false) ||
+      (u.email?.toLowerCase().includes(q) ?? false)
     );
   });
 

--- a/src/app/dashboard/projects/[id]/_components/TaskPanel.tsx
+++ b/src/app/dashboard/projects/[id]/_components/TaskPanel.tsx
@@ -3,11 +3,12 @@
 import { useRef, useState } from "react";
 import { api, type RouterOutputs } from "~/trpc/react";
 import { useUpload } from "~/lib/useUpload";
+import { areaColor } from "./areaColors";
 
 type Task = NonNullable<RouterOutputs["project"]["getTask"]>;
 
 const PRIORITY_OPTIONS = ["LOW", "MEDIUM", "HIGH", "URGENT"] as const;
-const STATUS_OPTIONS = ["TODO", "IN_PROGRESS", "IN_REVIEW", "DONE"] as const;
+const STATUS_OPTIONS = ["TODO", "IN_PROGRESS", "BLOCKED", "IN_REVIEW", "DONE"] as const;
 
 const PRIORITY_STYLES: Record<string, string> = {
   LOW: "bg-gray-100 text-gray-500 border-gray-200",
@@ -156,6 +157,15 @@ export function TaskPanel({
           )}
         </div>
 
+        {/* Blocked details — server clears these when status leaves BLOCKED */}
+        {task.status === "BLOCKED" && (
+          <BlockedSection
+            task={task}
+            isMember={isMember}
+            onUpdate={(patch) => updateTask.mutate({ id: task.id, ...patch })}
+          />
+        )}
+
         {/* Due date */}
         {isMember && (
           <div>
@@ -190,6 +200,13 @@ export function TaskPanel({
           task={task}
           isMember={isMember}
           onUpdate={(ids) => updateTask.mutate({ id: task.id, assigneeIds: ids })}
+        />
+
+        {/* Areas */}
+        <AreasEditor
+          task={task}
+          isMember={isMember}
+          onUpdate={(ids) => updateTask.mutate({ id: task.id, areaIds: ids })}
         />
 
         {/* Labels */}
@@ -425,6 +442,95 @@ function AttachmentsSection({
   );
 }
 
+function BlockedSection({
+  task,
+  isMember,
+  onUpdate,
+}: {
+  task: Task;
+  isMember: boolean;
+  onUpdate: (patch: { blockedReason?: string | null; blockedByAreaId?: string | null }) => void;
+}) {
+  const { data: areas } = api.project.getAreas.useQuery({ projectId: task.projectId });
+  // A task can't be waiting on an area it belongs to
+  const own = new Set(task.areas.map((a) => a.areaId));
+
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 p-3 space-y-2">
+      <p className="text-xs font-semibold text-red-700">⛔ Blocked</p>
+      <select
+        disabled={!isMember}
+        value={task.blockedByAreaId ?? ""}
+        onChange={(e) => onUpdate({ blockedByAreaId: e.target.value || null })}
+        className="w-full text-xs rounded border border-red-200 bg-white px-2 py-1 focus:outline-none focus:ring-1 focus:ring-red-400"
+      >
+        <option value="">Not waiting on an area</option>
+        {(areas ?? []).filter((a) => !own.has(a.id)).map((a) => (
+          <option key={a.id} value={a.id}>Waiting on {a.name}</option>
+        ))}
+      </select>
+      <textarea
+        key={task.id}
+        readOnly={!isMember}
+        rows={2}
+        defaultValue={task.blockedReason ?? ""}
+        placeholder="Why is this blocked?"
+        onBlur={(e) => {
+          const next = e.target.value.trim();
+          if (next !== (task.blockedReason ?? "")) onUpdate({ blockedReason: next || null });
+        }}
+        className="w-full text-xs rounded border border-red-200 bg-white px-2 py-1 focus:outline-none focus:ring-1 focus:ring-red-400"
+      />
+    </div>
+  );
+}
+
+/// Areas are a small fixed per-project set, so toggle chips beat a typeahead.
+function AreasEditor({
+  task,
+  isMember,
+  onUpdate,
+}: {
+  task: Task;
+  isMember: boolean;
+  onUpdate: (ids: string[]) => void;
+}) {
+  const { data: areas } = api.project.getAreas.useQuery({ projectId: task.projectId });
+  const current = task.areas.map((a) => a.areaId);
+  const shown = isMember
+    ? (areas ?? [])
+    : (areas ?? []).filter((a) => current.includes(a.id));
+
+  if (shown.length === 0) return null;
+
+  return (
+    <div>
+      <p className="text-xs font-medium text-gray-500 mb-1.5">Areas</p>
+      <div className="flex flex-wrap gap-1.5">
+        {shown.map((a) => {
+          const on = current.includes(a.id);
+          return (
+            <button
+              key={a.id}
+              disabled={!isMember}
+              onClick={() =>
+                onUpdate(on ? current.filter((id) => id !== a.id) : [...current, a.id])
+              }
+              className={`text-xs font-medium px-2 py-0.5 rounded transition-colors ${
+                on
+                  ? areaColor(a.color).chip
+                  : "bg-white text-gray-400 border border-gray-200 hover:bg-gray-50"
+              }`}
+            >
+              {a.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function AssigneesEditor({
   task,
   isMember,
@@ -448,8 +554,8 @@ function AssigneesEditor({
   const available = (projectMembers ?? []).filter(
     (m) =>
       !assignedIds.has(m.userId) &&
-      (m.user.name?.toLowerCase().includes(search.toLowerCase()) ??
-        m.user.email?.toLowerCase().includes(search.toLowerCase())),
+      ((m.user.name?.toLowerCase().includes(search.toLowerCase()) ?? false) ||
+        (m.user.email?.toLowerCase().includes(search.toLowerCase()) ?? false)),
   );
 
   function addAssignee(userId: string) {

--- a/src/app/dashboard/projects/[id]/_components/areaColors.ts
+++ b/src/app/dashboard/projects/[id]/_components/areaColors.ts
@@ -1,0 +1,28 @@
+// Palette for project areas.
+//
+// Tailwind v4 only emits classes it can see as literal strings, so every class
+// here MUST be spelled out. Never build these with template interpolation.
+
+export const AREA_COLORS = {
+  blue: { chip: "bg-blue-50 text-blue-700", dot: "bg-blue-500" },
+  green: { chip: "bg-green-50 text-green-700", dot: "bg-green-500" },
+  purple: { chip: "bg-purple-50 text-purple-700", dot: "bg-purple-500" },
+  orange: { chip: "bg-orange-50 text-orange-700", dot: "bg-orange-500" },
+  pink: { chip: "bg-pink-50 text-pink-700", dot: "bg-pink-500" },
+  teal: { chip: "bg-teal-50 text-teal-700", dot: "bg-teal-500" },
+  amber: { chip: "bg-amber-50 text-amber-700", dot: "bg-amber-500" },
+  indigo: { chip: "bg-indigo-50 text-indigo-700", dot: "bg-indigo-500" },
+  slate: { chip: "bg-slate-100 text-slate-700", dot: "bg-slate-500" },
+} as const;
+
+export type AreaColor = keyof typeof AREA_COLORS;
+
+export const AREA_COLOR_KEYS = Object.keys(AREA_COLORS) as AreaColor[];
+
+const FALLBACK = AREA_COLORS.slate;
+
+/// Resolves a stored color key to its class pair, tolerating null/unknown values.
+export function areaColor(color: string | null | undefined) {
+  if (!color) return FALLBACK;
+  return AREA_COLORS[color as AreaColor] ?? FALLBACK;
+}

--- a/src/server/api/routers/project.ts
+++ b/src/server/api/routers/project.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
+import type { PrismaClient } from "../../../../generated/prisma";
 import {
   createTRPCRouter,
   memberProcedure,
@@ -10,10 +11,41 @@ import { supabaseAdmin } from "~/lib/supabase-admin";
 
 // ─── Shared input schemas ────────────────────────────────────────────────────
 
-const taskStatusEnum = z.enum(["TODO", "IN_PROGRESS", "IN_REVIEW", "DONE"]);
+const taskStatusEnum = z.enum([
+  "TODO",
+  "IN_PROGRESS",
+  "BLOCKED",
+  "IN_REVIEW",
+  "DONE",
+]);
 const taskPriorityEnum = z.enum(["LOW", "MEDIUM", "HIGH", "URGENT"]);
 
-// ─── Auth helpers (inline — no separate helper fns to avoid type complexity) ─
+// ─── Auth helpers ────────────────────────────────────────────────────────────
+
+type Ctx = {
+  db: PrismaClient;
+  session: { user: { id: string; role: string } };
+};
+
+async function assertManager(ctx: Ctx, projectId: string) {
+  const { id: userId, role } = ctx.session.user;
+  if (role === "ADMIN") return;
+  const m = await ctx.db.projectMember.findUnique({
+    where: { projectId_userId: { projectId, userId } },
+    select: { role: true },
+  });
+  if (m?.role !== "PROJECT_MANAGER") throw new TRPCError({ code: "FORBIDDEN" });
+}
+
+/// Owning project of an area, or NOT_FOUND.
+async function areaProjectId(ctx: Ctx, id: string) {
+  const a = await ctx.db.projectArea.findUnique({
+    where: { id },
+    select: { projectId: true },
+  });
+  if (!a) throw new TRPCError({ code: "NOT_FOUND" });
+  return a.projectId;
+}
 
 export const projectRouter = createTRPCRouter({
   // ─── Projects ──────────────────────────────────────────────────────────────
@@ -217,6 +249,122 @@ export const projectRouter = createTRPCRouter({
       });
     }),
 
+  // ─── Areas ─────────────────────────────────────────────────────────────────
+
+  getAreas: protectedProcedure
+    .input(z.object({ projectId: z.string() }))
+    .query(({ ctx, input }) => {
+      const isAdmin = ctx.session.user.role === "ADMIN";
+      return ctx.db.projectArea.findMany({
+        where: {
+          projectId: input.projectId,
+          // Same private-project visibility rule as getTasks
+          ...(!isAdmin && {
+            OR: [
+              { project: { isPrivate: false } },
+              {
+                project: { members: { some: { userId: ctx.session.user.id } } },
+              },
+            ],
+          }),
+        },
+        include: {
+          members: {
+            include: {
+              user: { select: { id: true, name: true, image: true } },
+            },
+          },
+          _count: { select: { tasks: true } },
+        },
+        orderBy: [{ order: "asc" }, { name: "asc" }],
+      });
+    }),
+
+  createArea: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        name: z.string().min(1),
+        color: z.string().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertManager(ctx, input.projectId);
+      const count = await ctx.db.projectArea.count({
+        where: { projectId: input.projectId },
+      });
+      return ctx.db.projectArea.create({ data: { ...input, order: count } });
+    }),
+
+  updateArea: protectedProcedure
+    .input(
+      z.object({
+        id: z.string(),
+        name: z.string().min(1).optional(),
+        color: z.string().optional(),
+        order: z.number().int().optional(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { id, ...data } = input;
+      const projectId = await areaProjectId(ctx, id);
+      await assertManager(ctx, projectId);
+      return ctx.db.projectArea.update({ where: { id }, data });
+    }),
+
+  deleteArea: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      const projectId = await areaProjectId(ctx, input.id);
+      await assertManager(ctx, projectId);
+      // TaskArea rows cascade; tasks themselves survive, just untagged.
+      return ctx.db.projectArea.delete({ where: { id: input.id } });
+    }),
+
+  /// Replaces the full set of areas a member belongs to within a project.
+  setMemberAreas: protectedProcedure
+    .input(
+      z.object({
+        projectId: z.string(),
+        userId: z.string(),
+        areas: z.array(
+          z.object({ areaId: z.string(), isLead: z.boolean().default(false) }),
+        ),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      await assertManager(ctx, input.projectId);
+      // Guard against being handed area ids belonging to another project
+      const owned = await ctx.db.projectArea.findMany({
+        where: {
+          projectId: input.projectId,
+          id: { in: input.areas.map((a) => a.areaId) },
+        },
+        select: { id: true },
+      });
+      const ownedIds = new Set(owned.map((a) => a.id));
+      const areas = input.areas.filter((a) => ownedIds.has(a.areaId));
+
+      return ctx.db.$transaction(async (tx) => {
+        await tx.projectAreaMember.deleteMany({
+          where: { userId: input.userId, area: { projectId: input.projectId } },
+        });
+        if (areas.length) {
+          await tx.projectAreaMember.createMany({
+            data: areas.map((a) => ({ ...a, userId: input.userId })),
+          });
+        }
+        // At most one Area PM per area — promoting demotes the previous holder
+        const leadAreaIds = areas.filter((a) => a.isLead).map((a) => a.areaId);
+        if (leadAreaIds.length) {
+          await tx.projectAreaMember.updateMany({
+            where: { areaId: { in: leadAreaIds }, userId: { not: input.userId } },
+            data: { isLead: false },
+          });
+        }
+      });
+    }),
+
   getProjectLabels: protectedProcedure
     .input(z.object({ projectId: z.string() }))
     .query(async ({ ctx, input }) => {
@@ -387,6 +535,8 @@ export const projectRouter = createTRPCRouter({
               user: { select: { id: true, name: true, image: true } },
             },
           },
+          areas: { include: { area: true } },
+          blockedByArea: true,
           _count: { select: { comments: true } },
         },
         orderBy: { createdAt: "asc" },
@@ -415,6 +565,8 @@ export const projectRouter = createTRPCRouter({
               user: { select: { id: true, name: true, image: true } },
             },
           },
+          areas: { include: { area: true } },
+          blockedByArea: true,
           comments: {
             include: {
               user: { select: { id: true, name: true, image: true } },
@@ -443,6 +595,9 @@ export const projectRouter = createTRPCRouter({
         dueDate: z.date().optional(),
         labels: z.array(z.string()).default([]),
         assigneeIds: z.array(z.string()).default([]),
+        areaIds: z.array(z.string()).default([]),
+        blockedReason: z.string().nullable().optional(),
+        blockedByAreaId: z.string().nullable().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
@@ -457,15 +612,23 @@ export const projectRouter = createTRPCRouter({
         });
         if (!m) throw new TRPCError({ code: "FORBIDDEN" });
       }
-      const { assigneeIds, ...data } = input;
+      const { assigneeIds, areaIds, ...data } = input;
       return ctx.db.task.create({
         data: {
           ...data,
+          // Blocked details are only meaningful in the BLOCKED column
+          ...(data.status !== "BLOCKED" && {
+            blockedReason: null,
+            blockedByAreaId: null,
+          }),
           createdBy: ctx.session.user.id,
           assignees: assigneeIds.length
             ? {
                 createMany: { data: assigneeIds.map((userId) => ({ userId })) },
               }
+            : undefined,
+          areas: areaIds.length
+            ? { createMany: { data: areaIds.map((areaId) => ({ areaId })) } }
             : undefined,
         },
       });
@@ -482,10 +645,13 @@ export const projectRouter = createTRPCRouter({
         dueDate: z.date().nullable().optional(),
         labels: z.array(z.string()).optional(),
         assigneeIds: z.array(z.string()).optional(),
+        areaIds: z.array(z.string()).optional(),
+        blockedReason: z.string().nullable().optional(),
+        blockedByAreaId: z.string().nullable().optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const { id, assigneeIds, ...data } = input;
+      const { id, assigneeIds, areaIds, ...data } = input;
       const task = await ctx.db.task.findUnique({
         where: { id },
         select: { projectId: true },
@@ -508,12 +674,24 @@ export const projectRouter = createTRPCRouter({
         where: { id },
         data: {
           ...data,
+          // Moving a task out of BLOCKED clears the stale reason and target
+          ...(data.status !== undefined &&
+            data.status !== "BLOCKED" && {
+              blockedReason: null,
+              blockedByAreaId: null,
+            }),
           ...(assigneeIds !== undefined && {
             assignees: {
               deleteMany: {},
               createMany: {
                 data: assigneeIds.map((userId) => ({ userId })),
               },
+            },
+          }),
+          ...(areaIds !== undefined && {
+            areas: {
+              deleteMany: {},
+              createMany: { data: areaIds.map((areaId) => ({ areaId })) },
             },
           }),
         },


### PR DESCRIPTION
- Project areas — per-project areas  with member assignment, multi-area task tagging, and a single Area PM per area (label only, no permissions enforced).
- BLOCKED column between In Progress and In Review, with a reason and the area being waited on; both fields auto-clear when the task moves elsewhere.
- Area/person filters on the board and Members tab — filtering by an area also surfaces tasks blocked on it, marked ⛔ blocking you.

<img width="1529" height="788" alt="image" src="https://github.com/user-attachments/assets/57a5e190-3904-41f6-b652-14ce9325454e" />
<img width="1529" height="788" alt="image" src="https://github.com/user-attachments/assets/cc81d80c-cf0a-408c-bfca-861cc96e62f6" />
<img width="1529" height="788" alt="image" src="https://github.com/user-attachments/assets/673dea18-7ba2-48d9-8722-dd2c4205bbbf" />
